### PR TITLE
Tab-Bar Badge Preferences

### DIFF
--- a/packages/debug/src/browser/debug-preferences.ts
+++ b/packages/debug/src/browser/debug-preferences.ts
@@ -49,6 +49,11 @@ export const debugPreferencesSchema: PreferenceSchema = {
             enum: ['never', 'always', 'onFirstSessionStart'],
             description: 'Controls when the debug status bar should be visible.',
             default: 'onFirstSessionStart'
+        },
+        'debug.countBadge': {
+            type: 'boolean',
+            default: true,
+            description: 'Controls whether badges are enabled for the Debug view.'
         }
     }
 };
@@ -60,6 +65,7 @@ export class DebugConfiguration {
     'debug.internalConsoleOptions': 'neverOpen' | 'openOnSessionStart' | 'openOnFirstSessionStart';
     'debug.inlineValues': boolean;
     'debug.showInStatusBar': 'never' | 'always' | 'onFirstSessionStart';
+    'debug.countBadge': boolean;
 }
 
 export const DebugPreferences = Symbol('DebugPreferences');

--- a/packages/debug/src/browser/debug-tab-bar-decorator.ts
+++ b/packages/debug/src/browser/debug-tab-bar-decorator.ts
@@ -22,6 +22,7 @@ import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator
 import { Title, Widget } from '@theia/core/lib/browser';
 import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
 import { DisposableCollection } from '@theia/core/lib/common';
+import { DebugPreferences } from './debug-preferences';
 
 @injectable()
 export class DebugTabBarDecorator implements TabBarDecorator {
@@ -33,6 +34,9 @@ export class DebugTabBarDecorator implements TabBarDecorator {
     @inject(DebugSessionManager)
     protected readonly debugSessionManager: DebugSessionManager;
 
+    @inject(DebugPreferences)
+    protected readonly debugPreferences: DebugPreferences;
+
     @postConstruct()
     protected init(): void {
         this.toDispose.pushAll([
@@ -42,7 +46,8 @@ export class DebugTabBarDecorator implements TabBarDecorator {
     }
 
     decorate(title: Title<Widget>): WidgetDecoration.Data[] {
-        return (title.owner.id === DebugWidget.ID)
+        const countBadge = this.debugPreferences['debug.countBadge'];
+        return (countBadge && title.owner.id === DebugWidget.ID)
             ? [{ badge: this.debugSessionManager.sessions.length }]
             : [];
     }

--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -25,7 +25,7 @@ import { GitDiffHeaderWidget } from './git-diff-header-widget';
 import { ScmService } from '@theia/scm/lib/browser/scm-service';
 import { GitRepositoryProvider } from '../git-repository-provider';
 import { ScmTreeWidget } from '@theia/scm/lib/browser/scm-tree-widget';
-import { ScmPreferences } from '@theia/scm/lib/browser/scm-preferences';
+import { ScmPreferences, ScmViewMode } from '@theia/scm/lib/browser/scm-preferences';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -78,15 +78,15 @@ export class GitDiffWidget extends BaseWidget implements StatefulWidget {
         this.updateViewMode(this.scmPreferences.get('scm.defaultViewMode'));
         this.toDispose.push(this.scmPreferences.onPreferenceChanged(e => {
             if (e.preferenceName === 'scm.defaultViewMode') {
-                this.updateViewMode(e.newValue);
+                this.updateViewMode(e.newValue as ScmViewMode);
             }
         }));
     }
 
-    set viewMode(mode: 'tree' | 'list') {
+    set viewMode(mode: ScmViewMode) {
         this.resourceWidget.viewMode = mode;
     }
-    get viewMode(): 'tree' | 'list' {
+    get viewMode(): ScmViewMode {
         return this.resourceWidget.viewMode;
     }
 
@@ -104,7 +104,7 @@ export class GitDiffWidget extends BaseWidget implements StatefulWidget {
      * Updates the view mode based on the preference value.
      * @param preference the view mode preference.
      */
-    protected updateViewMode(preference: 'tree' | 'list'): void {
+    protected updateViewMode(preference: ScmViewMode): void {
         this.viewMode = preference;
     }
 

--- a/packages/git/src/browser/history/git-commit-detail-widget.tsx
+++ b/packages/git/src/browser/history/git-commit-detail-widget.tsx
@@ -26,7 +26,7 @@ import { GitCommitDetailHeaderWidget } from './git-commit-detail-header-widget';
 import { ScmService } from '@theia/scm/lib/browser/scm-service';
 import { GitDiffTreeModel } from '../diff/git-diff-tree-model';
 import { ScmTreeWidget } from '@theia/scm/lib/browser/scm-tree-widget';
-import { ScmPreferences } from '@theia/scm/lib/browser/scm-preferences';
+import { ScmPreferences, ScmViewMode } from '@theia/scm/lib/browser/scm-preferences';
 
 @injectable()
 export class GitCommitDetailWidget extends BaseWidget implements StatefulWidget {
@@ -39,10 +39,10 @@ export class GitCommitDetailWidget extends BaseWidget implements StatefulWidget 
     @inject(GitDiffTreeModel) protected readonly model: GitDiffTreeModel;
     @inject(ScmPreferences) protected readonly scmPreferences: ScmPreferences;
 
-    set viewMode(mode: 'tree' | 'list') {
+    set viewMode(mode: ScmViewMode) {
         this.resourceWidget.viewMode = mode;
     }
-    get viewMode(): 'tree' | 'list' {
+    get viewMode(): ScmViewMode {
         return this.resourceWidget.viewMode;
     }
 
@@ -78,7 +78,7 @@ export class GitCommitDetailWidget extends BaseWidget implements StatefulWidget 
         this.updateViewMode(this.scmPreferences.get('scm.defaultViewMode'));
         this.toDispose.push(this.scmPreferences.onPreferenceChanged(e => {
             if (e.preferenceName === 'scm.defaultViewMode') {
-                this.updateViewMode(e.newValue);
+                this.updateViewMode(e.newValue as ScmViewMode);
             }
         }));
 
@@ -99,7 +99,7 @@ export class GitCommitDetailWidget extends BaseWidget implements StatefulWidget 
      * Updates the view mode based on the preference value.
      * @param preference the view mode preference.
      */
-    protected updateViewMode(preference: 'tree' | 'list'): void {
+    protected updateViewMode(preference: ScmViewMode): void {
         this.viewMode = preference;
     }
 

--- a/packages/markers/src/browser/problem/problem-preferences.ts
+++ b/packages/markers/src/browser/problem/problem-preferences.ts
@@ -34,6 +34,11 @@ export const ProblemConfigSchema: PreferenceSchema = {
             'type': 'boolean',
             'description': 'Controls whether Problems view should reveal markers when file is opened.',
             'default': true
+        },
+        'problems.countBadge': {
+            type: 'boolean',
+            description: 'Controls whether badges are enabled for the Problems view.',
+            default: true
         }
     }
 };
@@ -41,7 +46,8 @@ export const ProblemConfigSchema: PreferenceSchema = {
 export interface ProblemConfiguration {
     'problems.decorations.enabled': boolean,
     'problems.decorations.tabbar.enabled': boolean,
-    'problems.autoReveal': boolean
+    'problems.autoReveal': boolean,
+    'problems.countBadge': boolean
 }
 
 export const ProblemPreferences = Symbol('ProblemPreferences');

--- a/packages/markers/src/browser/problem/problem-widget-tab-bar-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-widget-tab-bar-decorator.ts
@@ -20,6 +20,7 @@ import { ProblemManager } from './problem-manager';
 import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
 import { Title, Widget } from '@theia/core/lib/browser';
 import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
+import { ProblemPreferences } from './problem-preferences';
 
 @injectable()
 export class ProblemWidgetTabBarDecorator implements TabBarDecorator {
@@ -30,13 +31,17 @@ export class ProblemWidgetTabBarDecorator implements TabBarDecorator {
     @inject(ProblemManager)
     protected readonly problemManager: ProblemManager;
 
+    @inject(ProblemPreferences)
+    protected readonly problemPreferences: ProblemPreferences;
+
     @postConstruct()
     protected init(): void {
         this.problemManager.onDidChangeMarkers(() => this.fireDidChangeDecorations());
     }
 
     decorate(title: Title<Widget>): WidgetDecoration.Data[] {
-        if (title.owner.id === 'problems') {
+        const countBadge = this.problemPreferences['problems.countBadge'];
+        if (countBadge && title.owner.id === 'problems') {
             const { infos, warnings, errors } = this.problemManager.getProblemStat();
             const markerCount = infos + warnings + errors;
             return markerCount > 0 ? [{ badge: markerCount }] : [];

--- a/packages/navigator/src/browser/navigator-preferences.ts
+++ b/packages/navigator/src/browser/navigator-preferences.ts
@@ -24,12 +24,18 @@ export const FileNavigatorConfigSchema: PreferenceSchema = {
             type: 'boolean',
             description: 'Selects file under editing in the explorer.',
             default: true
-        }
+        },
+        'explorer.countBadge': {
+            type: 'boolean',
+            description: 'Controls whether badges are enabled for the Explorer.',
+            default: true
+        },
     }
 };
 
 export interface FileNavigatorConfiguration {
     'explorer.autoReveal': boolean;
+    'explorer.countBadge': boolean;
 }
 
 export const FileNavigatorPreferences = Symbol('NavigatorPreferences');

--- a/packages/navigator/src/browser/navigator-tab-bar-decorator.ts
+++ b/packages/navigator/src/browser/navigator-tab-bar-decorator.ts
@@ -14,16 +14,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable } from '@theia/core/shared/inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { Emitter, Event } from '@theia/core/lib/common/event';
 import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
 import { EXPLORER_VIEW_CONTAINER_ID } from './navigator-widget-factory';
 import { ApplicationShell, FrontendApplication, FrontendApplicationContribution, Saveable, Title, Widget } from '@theia/core/lib/browser';
 import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { FileNavigatorPreferences } from './navigator-preferences';
 
 @injectable()
 export class NavigatorTabBarDecorator implements TabBarDecorator, FrontendApplicationContribution {
+
+    @inject(FileNavigatorPreferences)
+    protected readonly fileNavigatorPreferences: FileNavigatorPreferences;
+
     readonly id = 'theia-navigator-tabbar-decorator';
     protected applicationShell: ApplicationShell;
 
@@ -48,7 +53,8 @@ export class NavigatorTabBarDecorator implements TabBarDecorator, FrontendApplic
     }
 
     decorate(title: Title<Widget>): WidgetDecoration.Data[] {
-        if (title.owner.id === EXPLORER_VIEW_CONTAINER_ID) {
+        const countBadge = this.fileNavigatorPreferences['explorer.countBadge'];
+        if (countBadge && title.owner.id === EXPLORER_VIEW_CONTAINER_ID) {
             const changes = this.getDirtyEditorsCount();
             return changes > 0 ? [{ badge: changes }] : [];
         } else {

--- a/packages/scm/src/browser/decorations/scm-tab-bar-decorator.ts
+++ b/packages/scm/src/browser/decorations/scm-tab-bar-decorator.ts
@@ -22,6 +22,7 @@ import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator
 import { Title, Widget } from '@theia/core/lib/browser';
 import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { ScmPreferences } from '../scm-preferences';
 
 @injectable()
 export class ScmTabBarDecorator implements TabBarDecorator {
@@ -34,6 +35,9 @@ export class ScmTabBarDecorator implements TabBarDecorator {
 
     @inject(ScmService)
     protected readonly scmService: ScmService;
+
+    @inject(ScmPreferences)
+    protected readonly scmPreferences: ScmPreferences;
 
     @postConstruct()
     protected init(): void {
@@ -49,7 +53,8 @@ export class ScmTabBarDecorator implements TabBarDecorator {
     }
 
     decorate(title: Title<Widget>): WidgetDecoration.Data[] {
-        if (title.owner.id === SCM_VIEW_CONTAINER_ID) {
+        const countBadge = this.scmPreferences['scm.countBadge'];
+        if (countBadge && title.owner.id === SCM_VIEW_CONTAINER_ID) {
             const changes = this.collectChangesCount();
             return changes > 0 ? [{ badge: changes }] : [];
         } else {

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -37,6 +37,7 @@ import { ScmQuickOpenService } from './scm-quick-open-service';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { ColorRegistry, Color } from '@theia/core/lib/browser/color-registry';
 import { ScmCommand } from './scm-provider';
+import { ScmViewMode } from './scm-preferences';
 
 export const SCM_WIDGET_FACTORY_ID = ScmWidget.ID;
 export const SCM_VIEW_CONTAINER_ID = 'scm-view-container';
@@ -159,7 +160,7 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
                 }
             }
         };
-        const registerToggleViewItem = (command: Command, mode: 'tree' | 'list') => {
+        const registerToggleViewItem = (command: Command, mode: ScmViewMode) => {
             const id = command.id;
             const item: TabBarToolbarItem = {
                 id,

--- a/packages/scm/src/browser/scm-preferences.ts
+++ b/packages/scm/src/browser/scm-preferences.ts
@@ -35,12 +35,18 @@ export const scmPreferenceSchema: PreferenceSchema = {
             ],
             description: 'Controls the default source control view mode.',
             default: 'list'
+        },
+        'scm.countBadge': {
+            type: 'boolean',
+            description: 'Controls whether badges are enabled for the Source Control Manager.',
+            default: true
         }
     }
 };
 
 export interface ScmConfiguration {
-    'scm.defaultViewMode': 'tree' | 'list'
+    'scm.defaultViewMode': 'tree' | 'list';
+    'scm.countBadge': boolean;
 }
 
 export const ScmPreferences = Symbol('ScmPreferences');

--- a/packages/scm/src/browser/scm-preferences.ts
+++ b/packages/scm/src/browser/scm-preferences.ts
@@ -23,6 +23,8 @@ import {
     PreferenceContribution
 } from '@theia/core/lib/browser/preferences';
 
+export type ScmViewMode = 'tree' | 'list';
+
 export const scmPreferenceSchema: PreferenceSchema = {
     type: 'object',
     properties: {
@@ -45,7 +47,7 @@ export const scmPreferenceSchema: PreferenceSchema = {
 };
 
 export interface ScmConfiguration {
-    'scm.defaultViewMode': 'tree' | 'list';
+    'scm.defaultViewMode': ScmViewMode;
     'scm.countBadge': boolean;
 }
 

--- a/packages/scm/src/browser/scm-tree-model.ts
+++ b/packages/scm/src/browser/scm-tree-model.ts
@@ -19,6 +19,7 @@ import { TreeModelImpl, TreeNode, TreeProps, CompositeTreeNode, SelectableTreeNo
 import URI from '@theia/core/lib/common/uri';
 import { ScmProvider, ScmResourceGroup, ScmResource, ScmResourceDecorations } from './scm-provider';
 import { ScmContextKeyService } from './scm-context-key-service';
+import { ScmViewMode } from './scm-preferences';
 
 export const ScmTreeModelProps = Symbol('ScmTreeModelProps');
 export interface ScmTreeModelProps {
@@ -94,8 +95,8 @@ export abstract class ScmTreeModel extends TreeModelImpl {
 
     abstract canTabToWidget(): boolean;
 
-    protected _viewMode: 'tree' | 'list' = 'list';
-    set viewMode(id: 'tree' | 'list') {
+    protected _viewMode: ScmViewMode = 'list';
+    set viewMode(id: ScmViewMode) {
         const oldSelection = this.selectedNodes;
         this._viewMode = id;
         if (this.root) {
@@ -109,7 +110,7 @@ export abstract class ScmTreeModel extends TreeModelImpl {
             }
         }
     }
-    get viewMode(): 'tree' | 'list' {
+    get viewMode(): ScmViewMode {
         return this._viewMode;
     }
 

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -33,6 +33,7 @@ import { EditorManager, DiffNavigatorProvider } from '@theia/editor/lib/browser'
 import { FileStat } from '@theia/filesystem/lib/common';
 import { IconThemeService } from '@theia/core/lib/browser/icon-theme-service';
 import { ScmFileChangeRootNode, ScmFileChangeGroupNode, ScmFileChangeFolderNode, ScmFileChangeNode } from './scm-tree-model';
+import { ScmViewMode } from './scm-preferences';
 
 @injectable()
 export class ScmTreeWidget extends TreeWidget {
@@ -69,13 +70,13 @@ export class ScmTreeWidget extends TreeWidget {
         this.model = treeModel as ScmTreeModel;
     }
 
-    set viewMode(id: 'tree' | 'list') {
+    set viewMode(id: ScmViewMode) {
         // Close the search box because the structure of the tree will change dramatically
         // and the search results will be out of date.
         this.searchBox.hide();
         this.model.viewMode = id;
     }
-    get viewMode(): 'tree' | 'list' {
+    get viewMode(): ScmViewMode {
         return this.model.viewMode;
     }
 

--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -27,7 +27,7 @@ import { ScmAmendWidget } from './scm-amend-widget';
 import { ScmNoRepositoryWidget } from './scm-no-repository-widget';
 import { ScmService } from './scm-service';
 import { ScmTreeWidget } from './scm-tree-widget';
-import { ScmPreferences } from './scm-preferences';
+import { ScmPreferences, ScmViewMode } from './scm-preferences';
 
 @injectable()
 export class ScmWidget extends BaseWidget implements StatefulWidget {
@@ -43,10 +43,10 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
     @inject(ScmNoRepositoryWidget) readonly noRepositoryWidget: ScmNoRepositoryWidget;
     @inject(ScmPreferences) protected readonly scmPreferences: ScmPreferences;
 
-    set viewMode(mode: 'tree' | 'list') {
+    set viewMode(mode: ScmViewMode) {
         this.resourceWidget.viewMode = mode;
     }
-    get viewMode(): 'tree' | 'list' {
+    get viewMode(): ScmViewMode {
         return this.resourceWidget.viewMode;
     }
 
@@ -80,7 +80,7 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
         this.updateViewMode(this.scmPreferences.get('scm.defaultViewMode'));
         this.toDispose.push(this.scmPreferences.onPreferenceChanged(e => {
             if (e.preferenceName === 'scm.defaultViewMode') {
-                this.updateViewMode(e.newValue);
+                this.updateViewMode(e.newValue as ScmViewMode);
             }
         }));
     }
@@ -93,7 +93,7 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
      * Updates the view mode based on the preference value.
      * @param preference the view mode preference.
      */
-    protected updateViewMode(preference: 'tree' | 'list'): void {
+    protected updateViewMode(preference: ScmViewMode): void {
         this.viewMode = preference;
     }
 

--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -83,7 +83,6 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
                 this.updateViewMode(e.newValue);
             }
         }));
-
     }
 
     get containerLayout(): PanelLayout {


### PR DESCRIPTION
Fixes #8709

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Allows user to enable/disable tab-bar count badges for Explorer, SCM, Debug and Problems views via Preferences.
- Creates new type for SCM view mode and refactors accordingly.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Go to Preferences and search 'Count Badge'.
2. Disable count badges for preferred views.
3. Observe that badges do not appear in the selected views when
changes are made to a file(s).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>