### PR TITLE
VSX: Count of Installed & Built-In Extensions

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-source.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.ts
@@ -17,6 +17,7 @@
 import { injectable, inject, postConstruct } from 'inversify';
 import { TreeSource, TreeElement } from '@theia/core/lib/browser/source-tree';
 import { VSXExtensionsModel } from './vsx-extensions-model';
+import { Emitter } from '@theia/core/lib/common';
 
 @injectable()
 export class VSXExtensionsSourceOptions {
@@ -35,10 +36,16 @@ export class VSXExtensionsSource extends TreeSource {
     @inject(VSXExtensionsModel)
     protected readonly model: VSXExtensionsModel;
 
+    protected readonly onDidUpdateEmitter = new Emitter<string>();
+    readonly onDidUpdate = this.onDidUpdateEmitter.event;
+
     @postConstruct()
     protected async init(): Promise<void> {
         this.fireDidChange();
-        this.toDispose.push(this.model.onDidChange(() => this.fireDidChange()));
+        this.toDispose.push(this.model.onDidChange(() => {
+            this.fireDidChange();
+            this.onDidChangeEmitter.fire();
+        }));
     }
 
     *getElements(): IterableIterator<TreeElement> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Related to [#6710](https://github.com/eclipse-theia/theia/issues/6710)

- Displays a count of `Installed` and `Built-In` extensions.

![image](https://user-images.githubusercontent.com/46289281/106298308-bc729200-6221-11eb-90ea-bfb30cd9597a.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the `Extensions` view.
2. Observe that counts are displayed in the toolbar item titles.
3. Install/uninstall extensions & observe that the count is updated.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>