### PR TITLE
VSX: Support Prefix Queries

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -46,6 +46,14 @@
     padding-bottom: calc(var(--theia-ui-padding)/2);
 }
 
+.theia-vsx-extensions-no-results {
+    padding-left: calc(var(--theia-ui-padding)*3);
+}
+
+.hide {
+    display: none !important;
+}
+
 .theia-vsx-extension {
     display: flex;
     flex-direction: row;
@@ -317,4 +325,3 @@
 .theia-vsx-extension-action-bar .action.prominent:hover {
     background-color: var(--theia-extensionButton-prominentHoverBackground);
 }
-

--- a/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
@@ -17,8 +17,9 @@
 import { injectable, inject, postConstruct } from 'inversify';
 import { ViewContainer, PanelLayout, ViewContainerPart, Message } from '@theia/core/lib/browser';
 import { VSXExtensionsSearchBar } from './vsx-extensions-search-bar';
-import { VSXExtensionsWidget, } from './vsx-extensions-widget';
+import { VSXExtensionsWidget } from './vsx-extensions-widget';
 import { VSXExtensionsModel } from './vsx-extensions-model';
+import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
 
 @injectable()
 export class VSXExtensionsViewContainer extends ViewContainer {
@@ -26,14 +27,19 @@ export class VSXExtensionsViewContainer extends ViewContainer {
     static ID = 'vsx-extensions-view-container';
     static LABEL = 'Extensions';
 
+    static NO_RESULTS_ID = 'view-container-no-results';
+
     @inject(VSXExtensionsSearchBar)
     protected readonly searchBar: VSXExtensionsSearchBar;
 
     @inject(VSXExtensionsModel)
     protected readonly model: VSXExtensionsModel;
 
+    @inject(VSXExtensionsSearchModel)
+    readonly search: VSXExtensionsSearchModel;
+
     @postConstruct()
-    protected init(): void {
+    protected async init(): Promise<void> {
         super.init();
         this.id = VSXExtensionsViewContainer.ID;
         this.addClass('theia-vsx-extensions-view-container');
@@ -43,6 +49,40 @@ export class VSXExtensionsViewContainer extends ViewContainer {
             iconClass: 'theia-vsx-extensions-icon',
             closeable: true
         });
+
+        this.toDispose.push(this.searchBar.onDidPrefixQuery(async prefix => {
+            if (prefix === 'builtin') {
+                this.showPart(VSXExtensionsWidget.BUILT_IN_ID);
+            } else if (prefix === 'installed') {
+                this.showPart(VSXExtensionsWidget.INSTALLED_ID);
+            }
+        }));
+
+        this.toDispose.push(this.model.onDidResults(async resultsCount => {
+            // Get the view extensions part to the display the message in.
+            const part = this.currentPart;
+            if (!part) {
+                return;
+            }
+
+            // Create an element that displays a message for no results.
+            const noResultsMsg = document.createElement('div');
+            noResultsMsg.id = VSXExtensionsViewContainer.NO_RESULTS_ID;
+            noResultsMsg.className = 'theia-vsx-extensions-no-results';
+            noResultsMsg.innerHTML = 'No extensions found.';
+
+            // Show or hide the message depending on number of results.
+            const msg = document.getElementById(VSXExtensionsViewContainer.NO_RESULTS_ID);
+            if (resultsCount === 0) {
+                if (!msg) {
+                    part.node.parentNode?.appendChild(noResultsMsg);
+                } else {
+                    msg.classList.remove('hide');
+                }
+            } else if (msg && resultsCount > 0) {
+                msg.classList.add('hide');
+            }
+        }));
     }
 
     protected onActivateRequest(msg: Message): void {
@@ -60,11 +100,16 @@ export class VSXExtensionsViewContainer extends ViewContainer {
         super.configureLayout(layout);
     }
 
+    protected registerPart(part: ViewContainerPart): void {
+        super.registerPart(part);
+        this.applyModeToPart(part);
+    }
+
     protected currentMode: VSXExtensionsViewContainer.Mode = VSXExtensionsViewContainer.InitialMode;
     protected readonly lastModeState = new Map<VSXExtensionsViewContainer.Mode, ViewContainer.State>();
 
     protected updateMode(): void {
-        const currentMode: VSXExtensionsViewContainer.Mode = !this.model.search.query ? VSXExtensionsViewContainer.DefaultMode : VSXExtensionsViewContainer.SearchResultMode;
+        const currentMode = this.getCurrentMode();
         if (currentMode === this.currentMode) {
             return;
         }
@@ -75,32 +120,93 @@ export class VSXExtensionsViewContainer extends ViewContainer {
         const lastState = this.lastModeState.get(currentMode);
         if (lastState) {
             super.doRestoreState(lastState);
+        }
+        this.getParts().find(part => this.applyModeToPart(part));
+    }
+
+    /**
+     * Returns the current view container mode.
+     */
+    protected getCurrentMode(): VSXExtensionsViewContainer.Mode {
+        let currentMode: VSXExtensionsViewContainer.Mode;
+        if (!this.model.search.query) {
+            currentMode = VSXExtensionsViewContainer.DefaultMode;
+            const noResultsMsg = document.getElementById(VSXExtensionsViewContainer.NO_RESULTS_ID);
+            noResultsMsg?.classList.add('hide');
+        } else if (this.search.query.startsWith('@installed')) {
+            currentMode = VSXExtensionsViewContainer.InstalledMode;
+        } else if (this.search.query.startsWith('@builtin')) {
+            currentMode = VSXExtensionsViewContainer.BuiltinMode;
         } else {
-            for (const part of this.getParts()) {
-                this.applyModeToPart(part);
-            }
+            currentMode = VSXExtensionsViewContainer.SearchResultMode;
         }
-        if (this.currentMode === VSXExtensionsViewContainer.SearchResultMode) {
-            const searchPart = this.getParts().find(part => part.wrapped.id === VSXExtensionsWidget.SEARCH_RESULT_ID);
-            if (searchPart) {
-                searchPart.collapsed = false;
-                searchPart.show();
-            }
-        }
+        return currentMode;
     }
 
-    protected registerPart(part: ViewContainerPart): void {
-        super.registerPart(part);
-        this.applyModeToPart(part);
+    /**
+     * Displays a specific widget and hides all other widgets.
+     *
+     * @param widgetId an extensions view widget.
+     */
+    protected showPart(widgetId: string): void {
+        this.getParts().find(part => {
+            if (part.wrapped.id === widgetId) {
+                this.currentPart = part;
+                part.collapsed = false;
+                part.show();
+            } else {
+                part.hide();
+            }
+        });
     }
 
+    /**
+     * Displays the part(s) associated with a particular mode.
+     *
+     * @param part the view container part.
+     */
     protected applyModeToPart(part: ViewContainerPart): void {
-        const partMode = (part.wrapped.id === VSXExtensionsWidget.SEARCH_RESULT_ID ? VSXExtensionsViewContainer.SearchResultMode : VSXExtensionsViewContainer.DefaultMode);
-        if (this.currentMode === partMode) {
-            part.show();
+        const partMode = this.getCorrespondingMode(part);
+        if (this.currentMode !== VSXExtensionsViewContainer.DefaultMode) {
+            // Display the widget corresponding to the current mode.
+            if (this.currentMode === partMode) {
+                this.currentPart = part;
+                part.collapsed = false;
+                part.show();
+            } else {
+                part.hide();
+            }
         } else {
-            part.hide();
+            // In Default Mode, show `Installed` and `Builtin` widgets.
+            if (part.wrapped.id === VSXExtensionsWidget.INSTALLED_ID || part.wrapped.id === VSXExtensionsWidget.BUILT_IN_ID) {
+                part.show();
+            } else {
+                part.hide();
+            }
         }
+    }
+
+    /**
+     * Returns the view container mode that corresponds to the given part.
+     *
+     * @param part the view container part.
+     */
+    protected getCorrespondingMode(part: ViewContainerPart): VSXExtensionsViewContainer.Mode {
+        let mode: VSXExtensionsViewContainer.Mode;
+        switch (part.wrapped.id) {
+            case VSXExtensionsWidget.SEARCH_RESULT_ID:
+                mode = VSXExtensionsViewContainer.SearchResultMode;
+                break;
+            case VSXExtensionsWidget.INSTALLED_ID:
+                mode = VSXExtensionsViewContainer.InstalledMode;
+                break;
+            case VSXExtensionsWidget.BUILT_IN_ID:
+                mode = VSXExtensionsViewContainer.BuiltinMode;
+                break;
+            default:
+                mode = VSXExtensionsViewContainer.DefaultMode;
+        }
+        return mode;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -133,7 +239,9 @@ export namespace VSXExtensionsViewContainer {
     export const InitialMode = 0;
     export const DefaultMode = 1;
     export const SearchResultMode = 2;
-    export type Mode = typeof InitialMode | typeof DefaultMode | typeof SearchResultMode;
+    export const InstalledMode = 3;
+    export const BuiltinMode = 4;
+    export type Mode = typeof InitialMode | typeof DefaultMode | typeof SearchResultMode | typeof InstalledMode | typeof BuiltinMode;
     export interface State {
         query: string;
         modes: {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #8070

- Supports search queries in the `Extensions` view prefixed with `@builtin` or `@installed`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

  1. Open the `Extensions` view
  2. In the search bar:
  - Type the  `@builtin` prefix followed by a search query to search all built-in extensions.
  - Type the `@installed` prefix followed by a search query to search all user-installed extensions.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>