### PR TITLE
Preferences: Support `window.zoomLevel` Preference

### DIFF
--- a/packages/core/src/electron-browser/window/electron-window-module.ts
+++ b/packages/core/src/electron-browser/window/electron-window-module.ts
@@ -22,11 +22,13 @@ import { ElectronClipboardService } from '../electron-clipboard-service';
 import { ClipboardService } from '../../browser/clipboard-service';
 import { ElectronMainWindowService, electronMainWindowServicePath } from '../../electron-common/electron-main-window-service';
 import { ElectronIpcConnectionProvider } from '../messaging/electron-ipc-connection-provider';
+import { bindWindowPreferences } from './electron-window-preferences';
 
 export default new ContainerModule(bind => {
     bind(ElectronMainWindowService).toDynamicValue(context =>
         ElectronIpcConnectionProvider.createProxy(context.container, electronMainWindowServicePath)
     ).inSingletonScope();
+    bindWindowPreferences(bind);
     bind(WindowService).to(ElectronWindowService).inSingletonScope();
     bind(FrontendApplicationContribution).toService(WindowService);
     bind(ClipboardService).to(ElectronClipboardService).inSingletonScope();

--- a/packages/core/src/electron-browser/window/electron-window-preferences.ts
+++ b/packages/core/src/electron-browser/window/electron-window-preferences.ts
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from 'inversify';
+import { createPreferenceProxy, PreferenceContribution, PreferenceProxy, PreferenceSchema, PreferenceService } from '../../browser/preferences';
+
+export namespace ZoomLevel {
+    export const DEFAULT = 0;
+    // copied from https://github.com/microsoft/vscode/blob/dda96b69bfc63f309e60cfc5f98cb863c46b32ac/src/vs/workbench/electron-sandbox/actions/windowActions.ts#L47-L48
+    export const MIN = -8;
+    export const MAX = 9;
+    // amount to increment or decrement the window zoom level.
+    export const VARIATION = 0.5;
+}
+
+export const electronWindowPreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        'window.zoomLevel': {
+            'type': 'number',
+            'default': ZoomLevel.DEFAULT,
+            'minimum': ZoomLevel.MIN,
+            'maximum': ZoomLevel.MAX,
+            'scope': 'application',
+            // eslint-disable-next-line max-len
+            'description': 'Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1.0) or below (e.g. -1.0) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.'
+        },
+    }
+};
+
+export class ElectronWindowConfiguration {
+    'window.zoomLevel': number;
+}
+
+export const ElectronWindowPreferences = Symbol('ElectronWindowPreferences');
+export type ElectronWindowPreferences = PreferenceProxy<ElectronWindowConfiguration>;
+
+export function createElectronWindowPreferences(preferences: PreferenceService): ElectronWindowPreferences {
+    return createPreferenceProxy(preferences, electronWindowPreferencesSchema);
+}
+
+export function bindWindowPreferences(bind: interfaces.Bind): void {
+    bind(ElectronWindowPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createElectronWindowPreferences(preferences);
+    }).inSingletonScope();
+
+    bind(PreferenceContribution).toConstantValue({ schema: electronWindowPreferencesSchema });
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #8751

- Allows end-user to specify window zoom level as a preference
- Adds support for the addition of other window preferences

![image](https://user-images.githubusercontent.com/46289281/108755161-e6635f80-7514-11eb-99cf-02308203f130.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open `Preferences` view and locate the `window.zoomLevel` preference
2. Enter in a custom value or change the zoom level using zoom commands (`ctrl +`, `ctrl -`, `ctrl 0`)
3. Observe that the window zoom level changes and the preference is updated in the `settings.json` file
4. Reload the window and observe that the preferred zoom level is restored

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>