### PR TITLE
VSX: Add 'Local' PluginType

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -53,7 +53,7 @@ import { DiffService } from '@theia/workspace/lib/browser/diff-service';
 import { inject, injectable } from 'inversify';
 import { Position } from '@theia/plugin-ext/lib/common/plugin-api-rpc';
 import { URI } from 'vscode-uri';
-import { PluginServer } from '@theia/plugin-ext/lib/common/plugin-protocol';
+import { PluginServer, PluginType } from '@theia/plugin-ext/lib/common/plugin-protocol';
 import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { TerminalFrontendContribution } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
 import { QuickOpenWorkspace } from '@theia/workspace/lib/browser/quick-open-workspace';
@@ -232,7 +232,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     await this.pluginServer.deploy(`vscode:extension/${vsixUriOrExtensionId}`);
                 } else {
                     const uriPath = isUriComponents(vsixUriOrExtensionId) ? URI.revive(vsixUriOrExtensionId).fsPath : await this.fileService.fsPath(vsixUriOrExtensionId);
-                    await this.pluginServer.deploy(`local-file:${uriPath}`);
+                    await this.pluginServer.deploy(`local-file:${uriPath}`, PluginType.Local);
                 }
             }
         });

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -382,11 +382,21 @@ export enum PluginDeployerEntryType {
 }
 
 /**
- * Whether a plugin installed by a user or system.
+ * Represents the different plugin installation types.
  */
 export enum PluginType {
+    /**
+     * Plugin installed by the system.
+     */
     System,
-    User
+    /**
+     * Plugin installed by the user.
+     */
+    User,
+    /**
+     * Plugin installed locally (upload).
+     */
+    Local
 };
 
 export interface PluginDeployerEntry {

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -126,6 +126,12 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
         return type === PluginType.System;
     }
 
+    get local(): boolean {
+        const plugin = this.plugin;
+        const type = plugin && plugin.type;
+        return type === PluginType.Local;
+    }
+
     update(data: Partial<VSXExtensionData>): void {
         for (const key of VSXExtensionData.KEYS) {
             if (key in data) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Adds `Local` as a `PluginType` to refer to plugins that are installed locally (e.g. uploaded using `Install From VSIX...`)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the extensions-view.
2. Install an extension using the `Install From VSIX...` command.
3. Confirm that the extension is of PluginType `Local`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>