### PR TITLE
VSX: Add Extension Context-Menu & Copy Commands

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -121,13 +121,15 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    white-space: nowrap;
 }
 
 .theia-vsx-extension-action-bar .action {
-    font-size: 80%;
+    font-size: 90%;
     min-width: auto !important;
     padding: 2px var(--theia-ui-padding) !important;
     margin-top: 2px;
+    vertical-align: middle;
 }
 
 /* Editor Section */
@@ -303,6 +305,7 @@
     margin-top: calc(var(--theia-ui-padding)*5/3);
     margin-left: 0px;
     padding: 1px var(--theia-ui-padding);
+    vertical-align: middle;
 }
 
 /** Theming */

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -27,6 +27,14 @@ import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { VSXEnvironment } from '../common/vsx-environment';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
 import { VSXExtensionNamespaceAccess, VSXUser } from '../common/vsx-registry-types';
+import { MenuPath } from '@theia/core/lib/common';
+import { ContextMenuRenderer } from '@theia/core/lib/browser';
+
+export const EXTENSIONS_CONTEXT_MENU: MenuPath = ['extensions_context_menu'];
+
+export namespace VSXExtensionsContextMenu {
+    export const COPY = [...EXTENSIONS_CONTEXT_MENU, '1_copy'];
+}
 
 @injectable()
 export class VSXExtensionData {
@@ -38,6 +46,7 @@ export class VSXExtensionData {
     readonly description?: string;
     readonly averageRating?: number;
     readonly downloadCount?: number;
+    readonly downloadUrl?: string;
     readonly readmeUrl?: string;
     readonly licenseUrl?: string;
     readonly repository?: string;
@@ -55,6 +64,7 @@ export class VSXExtensionData {
         'description',
         'averageRating',
         'downloadCount',
+        'downloadUrl',
         'readmeUrl',
         'licenseUrl',
         'repository',
@@ -91,6 +101,9 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
 
     @inject(ProgressService)
     protected readonly progressService: ProgressService;
+
+    @inject(ContextMenuRenderer)
+    protected readonly contextMenuRenderer: ContextMenuRenderer;
 
     @inject(VSXEnvironment)
     readonly environment: VSXEnvironment;
@@ -180,6 +193,10 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
         return this.getData('downloadCount');
     }
 
+    get downloadUrl(): string | undefined {
+        return this.getData('downloadUrl');
+    }
+
     get readmeUrl(): string | undefined {
         const plugin = this.plugin;
         const readmeUrl = plugin && plugin.metadata.model.readmeUrl;
@@ -253,6 +270,42 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
         }
     }
 
+    handleContextMenu(e: React.MouseEvent<HTMLElement, MouseEvent>): void {
+        e.preventDefault();
+        this.contextMenuRenderer.render({
+            menuPath: EXTENSIONS_CONTEXT_MENU,
+            anchor: {
+                x: e.clientX,
+                y: e.clientY,
+            },
+            args: [this]
+        });
+    }
+
+    /**
+     * Get the registry link for the given extension.
+     * @param path the url path.
+     * @returns the registry link for the given extension at the path.
+     */
+    async getRegistryLink(path = ''): Promise<URI> {
+        const uri = await this.environment.getRegistryUri();
+        return uri.resolve('extension/' + this.id.replace('.', '/')).resolve(path);
+    }
+
+    async serialize(): Promise<string> {
+        const serializedExtension: string[] = [];
+        serializedExtension.push(`Name: ${this.displayName}`);
+        serializedExtension.push(`Id: ${this.id}`);
+        serializedExtension.push(`Description: ${this.description}`);
+        serializedExtension.push(`Version: ${this.version}`);
+        serializedExtension.push(`Publisher: ${this.publisher}`);
+        if (this.downloadUrl !== undefined) {
+            const registryLink = await this.getRegistryLink();
+            serializedExtension.push(`Open VSX Link: ${registryLink.toString()}`);
+        };
+        return serializedExtension.join('\n');
+    }
+
     async open(options: OpenerOptions = { mode: 'reveal' }): Promise<void> {
         await this.doOpen(this.uri, options);
     }
@@ -289,11 +342,15 @@ export abstract class AbstractVSXExtensionComponent extends React.Component<Abst
         }
     };
 
+    protected readonly manage = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+        this.props.extension.handleContextMenu(e);
+    };
+
     protected renderAction(): React.ReactNode {
         const extension = this.props.extension;
         const { builtin, busy, installed } = extension;
         if (builtin) {
-            return undefined;
+            return <div className="codicon codicon-settings-gear action" onClick={this.manage}></div>;
         }
         if (busy) {
             if (installed) {
@@ -302,7 +359,8 @@ export abstract class AbstractVSXExtensionComponent extends React.Component<Abst
             return <button className="theia-button action prominent theia-mod-disabled">Installing</button>;
         }
         if (installed) {
-            return <button className="theia-button action" onClick={this.uninstall}>Uninstall</button>;
+            return <div><button className="theia-button action" onClick={this.uninstall}>Uninstall</button>
+                <div className="codicon codicon-settings-gear action" onClick={this.manage}></div></div>;
         }
         return <button className="theia-button prominent action" onClick={this.install}>Install</button>;
     }
@@ -475,8 +533,8 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
         e.preventDefault();
 
         const extension = this.props.extension;
-        const uri = await extension.environment.getRegistryUri();
-        extension.doOpen(uri.resolve('extension/' + extension.id.replace('.', '/')));
+        const uri = await extension.getRegistryLink();
+        extension.doOpen(uri);
     };
     readonly searchPublisher = (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -502,8 +560,8 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
         e.preventDefault();
 
         const extension = this.props.extension;
-        const uri = await extension.environment.getRegistryUri();
-        extension.doOpen(uri.resolve('extension/' + extension.id.replace('.', '/') + '/reviews'));
+        const uri = await extension.getRegistryLink('reviews');
+        extension.doOpen(uri);
     };
     readonly openRepository = (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -524,5 +582,4 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
             extension.doOpen(new URI(licenseUrl));
         }
     };
-
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Adds a context-menu to each extension to which extension-specific commands can be registered; accessible through the gear icon. (Potential extension-specific commands to add: `Install Another Version...`, `Enable`, `Disable`, `Extension Settings`.)
- Adds support for `Copy` and `Copy Extension Id` commands.

![image](https://user-images.githubusercontent.com/46289281/113187921-69b85500-9227-11eb-81cb-73768b83fce0.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Open the _extensions-view_.
- Select an extension and click the gear icon.
- Click either the `Copy` command or the `Copy Extension Id` command.
- Paste results in a text-editor to confirm that the appropriate information was copied.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>