### PR TITLE
Preferences: Additional 'Open Preferences' Commands

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -224,7 +224,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
             execute: () => this.quickOpen.open('')
         });
         commands.registerCommand({ id: 'workbench.action.openSettings' }, {
-            execute: () => commands.executeCommand(CommonCommands.OPEN_PREFERENCES.id)
+            execute: (query?: string) => commands.executeCommand(CommonCommands.OPEN_PREFERENCES.id, query)
         });
         commands.registerCommand({ id: VscodeCommands.INSTALL_FROM_VSIX.id }, {
             execute: async (vsixUriOrExtensionId: TheiaURI | UriComponents | string) => {

--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -105,6 +105,18 @@ export namespace PreferencesCommands {
         id: 'preferences:copyJson.value',
         label: 'Copy Setting as JSON',
     };
+
+    export const OPEN_USER_PREFERENCES: Command = {
+        id: 'workbench.action.openGlobalSettings',
+        category: 'Preferences',
+        label: 'Open User Preferences',
+    };
+
+    export const OPEN_WORKSPACE_PREFERENCES: Command = {
+        id: 'workbench.action.openWorkspaceSettings',
+        category: 'Preferences',
+        label: 'Open Workspace Preferences',
+    };
 }
 
 export namespace PreferenceMenus {

--- a/packages/preferences/src/browser/views/preference-scope-tabbar-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-scope-tabbar-widget.tsx
@@ -66,8 +66,15 @@ export class PreferencesScopeTabBar extends TabBar<Widget> implements StatefulWi
         return this.currentSelection;
     }
 
-    protected setNewScopeSelection(newSelection: Preference.SelectedScopeDetails): void {
+    get availableTitles(): Title.Dataset[] {
+        const availableTitles: Title.Dataset[] = [];
+        for (const title of this.titles) {
+            availableTitles.push(title.dataset);
+        }
+        return availableTitles;
+    }
 
+    setNewScopeSelection(newSelection: Preference.SelectedScopeDetails): void {
         const newIndex = this.titles.findIndex(title => title.dataset.scope === newSelection.scope);
         if (newIndex !== -1) {
             this.currentSelection = newSelection;

--- a/packages/preferences/src/browser/views/preference-searchbar-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-searchbar-widget.tsx
@@ -119,7 +119,7 @@ export class PreferencesSearchbarWidget extends ReactWidget implements StatefulW
         return search?.value;
     }
 
-    protected updateSearchTerm(searchTerm: string): void {
+    updateSearchTerm(searchTerm: string): void {
         const search = document.getElementById(PreferencesSearchbarWidget.SEARCHBAR_ID) as HTMLInputElement;
         if (!search) {
             return;

--- a/packages/preferences/src/browser/views/preference-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-widget.tsx
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { postConstruct, injectable, inject } from '@theia/core/shared/inversify';
-import { Panel, Widget, Message, StatefulWidget } from '@theia/core/lib/browser';
+import { Panel, Widget, Message, StatefulWidget, Title } from '@theia/core/lib/browser';
 import { PreferencesEditorState, PreferencesEditorWidget } from './preference-editor-widget';
 import { PreferencesTreeWidget } from './preference-tree-widget';
 import { PreferencesSearchbarState, PreferencesSearchbarWidget } from './preference-searchbar-widget';
@@ -48,6 +48,18 @@ export class PreferencesWidget extends Panel implements StatefulWidget {
 
     get currentScope(): Preference.SelectedScopeDetails {
         return this.tabBarWidget.currentScope;
+    }
+
+    get availableTitles(): Title.Dataset[] {
+        return this.tabBarWidget.availableTitles;
+    }
+
+    setScopeSelection(selection: Preference.SelectedScopeDetails): void {
+        this.tabBarWidget.setNewScopeSelection(selection);
+    }
+
+    updateSearchTerm(term: string): void {
+        this.searchbarWidget.updateSearchTerm(term);
     }
 
     protected onResize(msg: Widget.ResizeMessage): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Adds `Preferences: Open User Preferences` command, which opens the _preferences-view_ with `User` scope.
- Adds `Preferences: Open Workspace Preferences` command, which opens the _preferences-view_ with `Workspace` scope.
- Modifies `Settings: Open Preferences` command to be able to accept an optional `query` parameter. Pre-populates the search with this query upon opening the _preferences-view_.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the command palette and search `Preferences: Open User Preferences` or `Preferences: Open Workspace Preferences`.
2. Execute either command and confirm that the _preferences-view_ is opened with the correct scope.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 sean.a.tan@ericsson.com